### PR TITLE
WIP Decouple observable mixins

### DIFF
--- a/deque/deque-test.js
+++ b/deque/deque-test.js
@@ -65,13 +65,13 @@ describe("Deque", function () {
             spy(plus, minus, value); // ignore last arg
         };
         var deque = Deque();
-        var observer = deque.observeRangeChange(handler);
+        deque.rangeChangeDispatcher = {dispatch: handler};
         deque.push(1);
         deque.push(2, 3);
         deque.pop();
         deque.shift();
         deque.unshift(4, 5);
-        observer.cancel();
+        deque.rangeChangeDispatcher = null;
         deque.shift();
         expect(spy.args).toEqual([
             [[1], [], 0],

--- a/deque/package.json
+++ b/deque/package.json
@@ -18,7 +18,6 @@
     "sinon": "^1",
     "@collections/generic-collection": "^1",
     "@collections/generic-order": "^1",
-    "@collections/observable": "^1",
     "@collections/iterate": "^1",
     "@collections/copy": "^1",
     "@collections/equals": "^1"


### PR DESCRIPTION
As I begin rolling out packages in the `@collections` org, committing to these API’s has me reflecting on my certainty that they’re lasting and final. One thing I would like to change while we still have a chance is coupling to the observer implementations.

Rather than mixin observables, I would like to apply a delegate pattern so users can bring their own dispatch implementation.

I’ve started with `deque` to illustrate. In this change I remove the ObservableRange and ObservableProperty mixins. ObservableProperty is completely unnecessary, since you can just that API directly on any object. ObservableRange I would like to replace with `rangeChangeDispatcher` and `rangeWillChangeDispatcher` delegate objects.